### PR TITLE
README: add Install + MCP client setup at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,41 @@
 
 A Model Context Protocol (MCP) server exposing Swift compiler capabilities to LLM clients.
 
+## Install
+
+```sh
+git clone git@github.com:oozoofrog/swiftmcp.git
+cd swiftmcp
+swift build -c release
+cp .build/release/mcpswx /usr/local/bin/
+```
+
+The release binary lands at `.build/release/mcpswx`. Copying to `/usr/local/bin/` (or anywhere on `$PATH`) is optional — every snippet below also works with the absolute build path.
+
+## MCP client setup
+
+### Claude Code
+
+```sh
+claude mcp add swiftmcp /usr/local/bin/mcpswx
+```
+
+### Claude Desktop
+
+Add the server entry to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```jsonc
+{
+  "mcpServers": {
+    "swiftmcp": {
+      "command": "/usr/local/bin/mcpswx"
+    }
+  }
+}
+```
+
+Restart the client after editing the config so it picks up the new server.
+
 ## Status
 
 Early development. See [`.claude/PLAN.md`](./.claude/PLAN.md) for the staged implementation roadmap.


### PR DESCRIPTION
## Summary
- Adds an `## Install` section with the four-line build flow (clone, swift build -c release, copy mcpswx to /usr/local/bin)
- Adds an `## MCP client setup` section with copy-paste snippets for Claude Code (`claude mcp add`) and Claude Desktop (config JSON)
- Both sections sit at the top of README.md so an agent can copy-paste straight through

## Test plan
- [x] `head -50 README.md` confirms ordering: title → install → MCP setup → status → capabilities → architecture