### PR TITLE
Add curl-pipeable installer + README one-line install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ A Model Context Protocol (MCP) server exposing Swift compiler capabilities to LL
 
 ## Install
 
+### One-line install (recommended)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/oozoofrog/swiftmcp/main/scripts/install.sh | sh
+```
+
+Clones into a temp directory, runs `swift build -c release`, copies `mcpswx` into `~/.local/bin/`, and (if the `claude` CLI is on `PATH`) auto-registers the server with Claude Code. Override the install destination or pin a specific ref:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/oozoofrog/swiftmcp/main/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh
+curl -fsSL https://raw.githubusercontent.com/oozoofrog/swiftmcp/main/scripts/install.sh | SWIFTMCP_REF=v0.1.0 sh
+```
+
+Requires `swift`, `git`, and macOS. The script never invokes `sudo`; choose an `INSTALL_DIR` you can write to.
+
+### Manual install
+
 ```sh
 git clone git@github.com:oozoofrog/swiftmcp.git
 cd swiftmcp

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# swiftmcp installer: clone, build, copy the `mcpswx` binary to a destination
+# directory, then print MCP client wire-up snippets. Designed to be safe to
+# pipe from `curl … | sh` — no sudo unless the user explicitly opted into a
+# system path via INSTALL_DIR=/usr/local/bin.
+#
+# Usage (defaults: install to ~/.local/bin, ref = main):
+#   curl -fsSL https://raw.githubusercontent.com/oozoofrog/swiftmcp/main/scripts/install.sh | sh
+#
+# Override the install destination:
+#   curl -fsSL https://raw.githubusercontent.com/oozoofrog/swiftmcp/main/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh
+#
+# Pin to a specific commit / tag / branch:
+#   curl -fsSL https://raw.githubusercontent.com/oozoofrog/swiftmcp/main/scripts/install.sh | SWIFTMCP_REF=v0.1.0 sh
+
+set -euo pipefail
+
+REPO_URL="${SWIFTMCP_REPO:-https://github.com/oozoofrog/swiftmcp.git}"
+REF="${SWIFTMCP_REF:-main}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+BIN_NAME="mcpswx"
+
+log() {
+    printf '\033[1;34m[swiftmcp]\033[0m %s\n' "$*"
+}
+
+err() {
+    printf '\033[1;31m[swiftmcp:error]\033[0m %s\n' "$*" >&2
+    exit 1
+}
+
+# Preflight: macOS host + Swift toolchain reachable.
+case "$(uname -s)" in
+    Darwin) ;;
+    *) err "swiftmcp currently targets macOS; uname reports $(uname -s)." ;;
+esac
+
+if ! command -v swift >/dev/null 2>&1; then
+    err "swift not found on PATH. Install Xcode (https://developer.apple.com/xcode/) or a standalone toolchain (https://swift.org/install/), then re-run."
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+    err "git not found on PATH."
+fi
+
+SWIFT_VERSION="$(swift --version | head -1)"
+log "swift: $SWIFT_VERSION"
+
+# Build out of a temp clone so the script is safe to pipe from curl on any
+# host, regardless of cwd. The clone is shallow + branch-pinned so the
+# bandwidth + disk footprint stays small.
+WORK_DIR="$(mktemp -d -t swiftmcp-install)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+log "cloning $REPO_URL@$REF into $WORK_DIR"
+git clone --depth 1 --branch "$REF" "$REPO_URL" "$WORK_DIR/swiftmcp" >/dev/null 2>&1 || \
+    err "git clone failed. If you pinned a non-default ref via SWIFTMCP_REF, confirm it exists on origin."
+
+cd "$WORK_DIR/swiftmcp"
+
+log "swift build -c release (this builds the mcpswx executable; a few minutes on a first run)"
+swift build -c release
+
+BIN_PATH=".build/release/$BIN_NAME"
+if [ ! -x "$BIN_PATH" ]; then
+    err "build finished but $BIN_PATH is not executable; check the build log above for diagnostics."
+fi
+
+# Install destination. We default to ~/.local/bin to avoid sudo; users who
+# want /usr/local/bin can override INSTALL_DIR explicitly.
+mkdir -p "$INSTALL_DIR"
+INSTALL_PATH="$INSTALL_DIR/$BIN_NAME"
+cp "$BIN_PATH" "$INSTALL_PATH"
+chmod +x "$INSTALL_PATH"
+log "installed: $INSTALL_PATH"
+
+# PATH sanity check — many users have ~/.local/bin missing from PATH on a
+# fresh shell. We don't try to edit shell rc files (too many variants); we
+# just print the explicit warning so the user can fix it themselves.
+case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+        log "note: $INSTALL_DIR is not on your \$PATH. Add it (e.g. echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc) or invoke mcpswx with its absolute path: $INSTALL_PATH"
+        ;;
+esac
+
+# Optional convenience: register with Claude Code automatically if the CLI
+# is available. Skipped silently otherwise so the script stays idempotent
+# on hosts that don't run Claude.
+if command -v claude >/dev/null 2>&1; then
+    if claude mcp list 2>/dev/null | grep -q '^swiftmcp\b'; then
+        log "Claude Code already has a 'swiftmcp' entry; skipping registration. Re-register with: claude mcp remove swiftmcp && claude mcp add swiftmcp $INSTALL_PATH"
+    else
+        log "registering with Claude Code"
+        if ! claude mcp add swiftmcp "$INSTALL_PATH"; then
+            log "claude mcp add failed; register manually: claude mcp add swiftmcp $INSTALL_PATH"
+        fi
+    fi
+else
+    log "claude CLI not found; register manually with: claude mcp add swiftmcp $INSTALL_PATH"
+fi
+
+cat <<EOF
+
+Done. Next steps for other MCP clients:
+
+  Claude Desktop — add to ~/Library/Application Support/Claude/claude_desktop_config.json:
+    {
+      "mcpServers": {
+        "swiftmcp": {
+          "command": "$INSTALL_PATH"
+        }
+      }
+    }
+  Then restart Claude Desktop.
+
+EOF


### PR DESCRIPTION
## Summary
- Adds `scripts/install.sh` — clones, builds release, copies `mcpswx` into `~/.local/bin/` by default, auto-registers with Claude Code if available
- Honors `INSTALL_DIR` and `SWIFTMCP_REF` env vars
- Skips Claude Code re-registration if entry already exists (idempotent)
- README now leads Install section with a curl one-liner; manual flow kept as fallback

## Test plan
- [x] `bash -n scripts/install.sh` syntax check passes
- [x] README ordering verified: title → install (one-liner + manual) → MCP setup → status